### PR TITLE
feat: add 'comdb: false' to replication

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,13 @@ ComDB adds and extends several methods to PouchDB and any instances of it:
 
 ComDB wraps PouchDB's replicator to check if either the source or the target have an `_encrypted` attribute, reflecting that they are ComDB instances. If it finds the attribute, it changes the parameter to use the encrypted database rather than its decrypted one. If neither the source or target is a ComDB instance, the replicator behaves as normal.
 
+You can also disable this functionality by passing `comdb: false` in the `opts`
+parameter:
+
+```javascript
+PouchDB.replicate(db1, db2, { comdb: false })
+```
+
 The instance methods `db.replicate.to` and `db.replicate.from` automatically use `PouchDB.replicate` so that wrapping the static method causes the instance methods to exhibit the same behavior.
 
 Original: [`PouchDB.replicate`](https://pouchdb.com/api.html#replication)

--- a/index.js
+++ b/index.js
@@ -70,8 +70,10 @@ module.exports = function (PouchDB) {
   }
   // replication wrapper; handles ComDB instances transparently
   PouchDB.replicate = function (source, target, opts = {}, callback) {
-    if (source._encrypted) source = source._encrypted
-    if (target._encrypted) target = target._encrypted
+    if (opts.comdb !== false) {
+      if (source._encrypted) source = source._encrypted
+      if (target._encrypted) target = target._encrypted
+    }
     const promise = replicate(source, target, opts)
     return cbify(promise, callback)
   }

--- a/test/index.js
+++ b/test/index.js
@@ -103,6 +103,21 @@ describe('ComDB', function () {
         })
       })
     })
+
+    it('should perform normal replication ok', async function () {
+      return this.db.replicate.to(this.db2, { comdb: false }).then(() => {
+        const opts = { include_docs: true }
+        return Promise.all([
+          this.db.allDocs(opts),
+          this.db2.allDocs(opts)
+        ]).then(([results1, results2]) => {
+          assert.strictEqual(results1.total_rows, results2.total_rows)
+          const doc1 = results1.rows[0].doc
+          const doc2 = results2.rows[0].doc
+          assert(isEqual(doc1, doc2))
+        })
+      })
+    })
   })
 
   describe('issues', function () {


### PR DESCRIPTION
Allows normal replication between databases. Useful when you want to pull documents into the decrypted database from another decrypted source.