### PR TITLE
Feat/load encrypted

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ db.post({
 
 Now you can check the CouchDB for the encrypted information:
 
-```bash
+```
 $ curl "$COUCH_URL/FALGSC/_all_docs?include_docs=true" | jq .
 {
   "total_rows": 1,
@@ -173,6 +173,20 @@ ComDB wraps PouchDB's database destruction method so that both the encrypted and
 - `unencrypted_only`: Destroy only the unencrypted database. This is useful if you are using a remote encrypted backup and want to burn the local device so you can restore from backup on a fresh one.
 
 Original: [db.destroy](https://pouchdb.com/api.html#delete_database)
+
+### `db.loadEncrypted(callback)`
+
+Load changes from the encrypted database into the decrypted one. Useful if you are restoring from backup:
+
+```javascript
+// in-memory database is wiped on restart and so needs to be repopulated
+const db = new PouchDB('local', { adapter: 'memory' })
+// the encrypted DB lives on remote disk, so we can load docs from it
+db.setPassword(PASSWORD, { name: REMOTE_URL })
+db.loadEncrypted().then(() => {
+  // all encrypted docs have been loaded into the decrypted database
+})
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -208,7 +208,9 @@ db.loadEncrypted().then(() => {
 You can then replicate your encrypted database with a remote CouchDB installation to ensure you can restore your data even if your device is compromised:
 
 ```javascript
+// create remote db connection
 const remoteDb = new PouchDB('http://...') // CouchDB connection string
+// sync local encrypted with remote
 const sync = PouchDB.sync(db, remoteDb, { live: true, retry: true })
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "comdb",
-  "version": "1.2.0-beta",
+  "version": "1.3.0-beta",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.2.0-beta",
+      "version": "1.3.0-beta",
       "license": "Apache-2.0",
       "dependencies": {
         "lodash.isequal": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comdb",
-  "version": "1.2.0-beta",
+  "version": "1.3.0-beta",
   "description": "A PouchDB plugin that transparently encrypts and decrypts its data.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Add a `.loadEncrypted` method that iterates over changes in the encrypted database, loading them one by one into the decrypted database. This is crucial when restoring the decrypted database from an encrypted copy.

This PR also includes a recipe for instrumenting E2E encryption.