### PR TITLE
Update dependencies; minor refactor

### DIFF
--- a/examples/couchdb.js
+++ b/examples/couchdb.js
@@ -60,7 +60,7 @@ will replicate our first database to our second...
   `)
   db2 = new PouchDB('.comdb-example-2')
   const keyDoc = await db.get('_local/comdb')
-  delete(keyDoc._rev)
+  delete keyDoc._rev
   await db2.put(keyDoc)
   await db2.setPassword(password)
   await db.replicate.to(db2)

--- a/examples/couchdb.js
+++ b/examples/couchdb.js
@@ -22,7 +22,7 @@ that maps changes to and from your database. In this example, the
 encrypted database exists on a CouchDB instance, while the decrypted
 one lives on disk.
   `)
-  db.setPassword(password, {
+  await db.setPassword(password, {
     name: [COUCH_URL, 'comdb-example'].join('/')
   })
   const { id } = await db.post({ greetings: 'hello world' })
@@ -44,8 +44,8 @@ This document lives in CouchDB such that your decrypted data never
 leaves the local machine.
   `)
   console.log(doc)
-  const { id } = JSON.parse(await db._crypt.decrypt(doc.payload))
-  return db._encrypted.get(id)
+  const { _id: id } = JSON.parse(await db._crypt.decrypt(doc.payload))
+  return db.get(id)
 }).then((doc) => {
   console.log(`
 Here is the payload from that document, decrypted:
@@ -59,7 +59,10 @@ password, it will transparently decrypt replicated documents. Now I
 will replicate our first database to our second...
   `)
   db2 = new PouchDB('.comdb-example-2')
-  db2.setPassword(password)
+  const keyDoc = await db.get('_local/comdb')
+  delete(keyDoc._rev)
+  await db2.put(keyDoc)
+  await db2.setPassword(password)
   await db.replicate.to(db2)
   const { rows } = await db2.allDocs({ include_docs: true, limit: 1 })
   const { doc } = rows[0]

--- a/index.js
+++ b/index.js
@@ -36,18 +36,15 @@ module.exports = function (PouchDB) {
     let promise
     if (!this._encrypted || opts.unencrypted_only) {
       // istanbul ignore else
-      if (!this._destroyed)
-        promise = destroy.call(this, opts)
+      if (!this._destroyed) { promise = destroy.call(this, opts) }
     } else if (opts.encrypted_only) {
       // istanbul ignore else
-      if (!this._encrypted._destroyed)
-        promise = destroy.call(this._encrypted, opts)
+      if (!this._encrypted._destroyed) { promise = destroy.call(this._encrypted, opts) }
     } else {
       const promises = []
-      if (!this._destroyed)
-        promises.push(destroy.call(this, opts))
-      if (!this._encrypted._destroyed)
-        promises.push(destroy.call(this._encrypted, opts))
+      if (!this._destroyed) { promises.push(destroy.call(this, opts)) }
+      if (!this._encrypted._destroyed) { promises.push(destroy.call(this._encrypted, opts)) }
+      promise = Promise.all(promises)
     }
     return promise
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,12 @@
       "version": "4.0.0-beta",
       "license": "Apache-2.0",
       "dependencies": {
-        "garbados-crypt": "^1.0.2-alpha",
-        "transform-pouch": "^1.1.5",
+        "garbados-crypt": "^3.0.0-alpha",
+        "pouchdb-wrappers": "^5.0.0",
+        "transform-pouch": "^2.0.0",
         "tweetnacl": "^1.0.3",
-        "tweetnacl-util": "^0.15.1"
+        "tweetnacl-util": "^0.15.1",
+        "uuid": "^8.1.0"
       },
       "devDependencies": {
         "babel-plugin-istanbul": "^6.0.0",
@@ -764,6 +766,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true,
       "engines": {
         "node": ">=0.4.2"
       }
@@ -850,7 +853,8 @@
     "node_modules/argsarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/argsarray/-/argsarray-0.0.1.tgz",
-      "integrity": "sha1-bnIHtOzbObCviDA/pa4ivajfYcs="
+      "integrity": "sha1-bnIHtOzbObCviDA/pa4ivajfYcs=",
+      "dev": true
     },
     "node_modules/array-filter": {
       "version": "1.0.0",
@@ -964,14 +968,6 @@
         "inherits": "2.0.1"
       }
     },
-    "node_modules/ast-types": {
-      "version": "0.9.6",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
-      "integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk=",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
@@ -1027,15 +1023,8 @@
     "node_modules/balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-    },
-    "node_modules/base62": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/base62/-/base62-1.2.8.tgz",
-      "integrity": "sha512-V6YHUbjLxN1ymqNLb1DPHoU1CpfdL7d2YTIp5W3U4hhoG4hhxNmsFDs66M9EXxBiSEke5Bt5dwdfMwwZF70iLA==",
-      "engines": {
-        "node": "*"
-      }
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -1110,6 +1099,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1813,58 +1803,17 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-    },
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
-    "node_modules/commoner": {
-      "version": "0.10.8",
-      "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
-      "integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
-      "dependencies": {
-        "commander": "^2.5.0",
-        "detective": "^4.3.1",
-        "glob": "^5.0.15",
-        "graceful-fs": "^4.1.2",
-        "iconv-lite": "^0.4.5",
-        "mkdirp": "^0.5.0",
-        "private": "^0.1.6",
-        "q": "^1.1.2",
-        "recast": "^0.11.17"
-      },
-      "bin": {
-        "commonize": "bin/commonize"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/commoner/node_modules/glob": {
-      "version": "5.0.15",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-      "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-      "dependencies": {
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "2 || 3",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "node_modules/concat-stream": {
       "version": "1.6.2",
@@ -2018,7 +1967,8 @@
     "node_modules/core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "node_modules/coverify": {
       "version": "1.5.1",
@@ -2272,7 +2222,8 @@
     "node_modules/defined": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+      "dev": true
     },
     "node_modules/dependency-check": {
       "version": "4.1.0",
@@ -2383,26 +2334,6 @@
       "dependencies": {
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
-      }
-    },
-    "node_modules/detective": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
-      "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
-      "dependencies": {
-        "acorn": "^5.2.1",
-        "defined": "^1.0.0"
-      }
-    },
-    "node_modules/detective/node_modules/acorn": {
-      "version": "5.7.4",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
-      "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/devtools-protocol": {
@@ -2675,28 +2606,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/es3ify": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/es3ify/-/es3ify-0.2.2.tgz",
-      "integrity": "sha1-Xa4+ZQ5b42hLiAZlE9Uo0JJimGI=",
-      "dependencies": {
-        "esprima": "^2.7.1",
-        "jstransform": "~11.0.0",
-        "through": "~2.3.4"
-      }
-    },
-    "node_modules/es3ify/node_modules/esprima": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE=",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/es6-error": {
@@ -3130,11 +3039,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/esmangle-evaluator": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/esmangle-evaluator/-/esmangle-evaluator-1.0.1.tgz",
-      "integrity": "sha1-Yg2GbvSGGzMR91dm1SqFcrs8YzY="
-    },
     "node_modules/espree": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
@@ -3169,18 +3073,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/esprima-fb": {
-      "version": "15001.1.0-dev-harmony-fb",
-      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz",
-      "integrity": "sha1-MKlHMDxrjV6VW+4rmbHSMyBqaQE=",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/esquery": {
@@ -3289,31 +3181,6 @@
       },
       "optionalDependencies": {
         "@types/yauzl": "^2.9.1"
-      }
-    },
-    "node_modules/falafel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
-      "integrity": "sha1-wY0k71CRF0pJfzGM0ksCaiXN2rQ=",
-      "dependencies": {
-        "acorn": "^1.0.3",
-        "foreach": "^2.0.5",
-        "isarray": "0.0.1",
-        "object-keys": "^1.0.6"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/falafel/node_modules/acorn": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
-      "integrity": "sha1-yM4n3grMdtiW0rH6099YjZ6C8BQ=",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3540,7 +3407,8 @@
     "node_modules/foreach": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
     },
     "node_modules/foreground-child": {
       "version": "2.0.0",
@@ -3614,12 +3482,16 @@
       "dev": true
     },
     "node_modules/garbados-crypt": {
-      "version": "1.0.2-alpha",
-      "resolved": "https://registry.npmjs.org/garbados-crypt/-/garbados-crypt-1.0.2-alpha.tgz",
-      "integrity": "sha512-bvauUqqSvrvIN+JM84OXOBI2u7j6WCtm4+rbdkZAjXBn2gjgvM3bpBLexh4xQYYzHin3ZxUO6DylTQ6+rtCHoQ==",
+      "version": "3.0.0-beta",
+      "resolved": "https://registry.npmjs.org/garbados-crypt/-/garbados-crypt-3.0.0-beta.tgz",
+      "integrity": "sha512-Jw9AnRv4WcfuB7djeBc6IFmXz4VPf14srwvPuoIaOYPfuIibDl7prBC2j0+qL/NPZfwrVZer7h2o6TgGYFoOkA==",
       "dependencies": {
+        "hash-wasm": "^4.9.0",
         "tweetnacl": "^1.0.3",
         "tweetnacl-util": "^0.15.1"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/gensync": {
@@ -3774,7 +3646,8 @@
     "node_modules/graceful-fs": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "dev": true
     },
     "node_modules/growl": {
       "version": "1.10.5",
@@ -3864,6 +3737,11 @@
         "safe-buffer": "~5.2.0"
       }
     },
+    "node_modules/hash-wasm": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/hash-wasm/-/hash-wasm-4.9.0.tgz",
+      "integrity": "sha512-7SW7ejyfnRxuOc7ptQHSf4LDoZaWOivfzqw+5rpcQku0nHfmicPKE51ra9BiRLAmT8+gGLestr1XroUkqdjL6w=="
+    },
     "node_modules/hash.js": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
@@ -3950,17 +3828,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -4034,6 +3901,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -4042,36 +3910,8 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "node_modules/inline-process-browser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/inline-process-browser/-/inline-process-browser-1.0.0.tgz",
-      "integrity": "sha1-RqYbFT3TybFiSxoAYm7bT39BTyI=",
-      "dependencies": {
-        "falafel": "^1.0.1",
-        "through2": "^0.6.5"
-      }
-    },
-    "node_modules/inline-process-browser/node_modules/readable-stream": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
-    "node_modules/inline-process-browser/node_modules/through2": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-      "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-      "dependencies": {
-        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-        "xtend": ">=4.0.0 <4.1.0-0"
-      }
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "node_modules/inline-source-map": {
       "version": "0.6.2",
@@ -4480,7 +4320,8 @@
     "node_modules/isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -4746,32 +4587,6 @@
         "node": "*"
       }
     },
-    "node_modules/jstransform": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-11.0.3.tgz",
-      "integrity": "sha1-CaeJk+CuTU70SH9hVakfYZDLQiM=",
-      "dependencies": {
-        "base62": "^1.1.0",
-        "commoner": "^0.10.1",
-        "esprima-fb": "^15001.1.0-dev-harmony-fb",
-        "object-assign": "^2.0.0",
-        "source-map": "^0.4.2"
-      },
-      "bin": {
-        "jstransform": "bin/jstransform"
-      },
-      "engines": {
-        "node": ">=0.8.8"
-      }
-    },
-    "node_modules/jstransform/node_modules/object-assign": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-      "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/jsx-ast-utils": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.0.tgz",
@@ -4972,22 +4787,6 @@
       "engines": {
         "node": ">= 0.8.0"
       }
-    },
-    "node_modules/lie": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lie/-/lie-3.0.4.tgz",
-      "integrity": "sha1-vHrh6+fxyN45r9zU94kHa0ew9jQ=",
-      "dependencies": {
-        "es3ify": "^0.2.2",
-        "immediate": "~3.0.5",
-        "inline-process-browser": "^1.0.0",
-        "unreachable-branch-transform": "^0.3.0"
-      }
-    },
-    "node_modules/lie/node_modules/immediate": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
     },
     "node_modules/listen": {
       "version": "1.0.1",
@@ -5265,6 +5064,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -5275,12 +5075,14 @@
     "node_modules/minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
     },
     "node_modules/mkdirp": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
       "dependencies": {
         "minimist": "^1.2.5"
       },
@@ -6234,6 +6036,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -6311,6 +6114,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -6484,6 +6288,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6868,26 +6673,10 @@
         "vuvuzela": "1.0.3"
       }
     },
-    "node_modules/pouchdb-extend": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/pouchdb-extend/-/pouchdb-extend-0.1.2.tgz",
-      "integrity": "sha1-0c5RG/cE7S4p979CikFqz/+hJLg="
-    },
-    "node_modules/pouchdb-promise": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/pouchdb-promise/-/pouchdb-promise-5.4.3.tgz",
-      "integrity": "sha1-Mx1nCxmJ1aA/JogRIU8n9UFQyys=",
-      "dependencies": {
-        "lie": "3.0.4"
-      }
-    },
     "node_modules/pouchdb-wrappers": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/pouchdb-wrappers/-/pouchdb-wrappers-4.1.0.tgz",
-      "integrity": "sha512-L94K7zgb2tFSvU/iAj1EHK8fC13vKWzzy8kc9HBu9s1jtZSfD34cbWG6qUIvlu61Fso2byp8fsOvp+l5hFiRmg==",
-      "dependencies": {
-        "promise-nodify": "^1.0.2"
-      }
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pouchdb-wrappers/-/pouchdb-wrappers-5.0.0.tgz",
+      "integrity": "sha512-fXqsVn+rmlPtxaAIGaQP5TkiaT39OMwvMk+ScLLtHrmfXD2KBO6fe/qBl38N/rpTn0h/A058dPN4fLAHt550zA=="
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -6896,14 +6685,6 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/private": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/process": {
@@ -6941,11 +6722,6 @@
       "engines": {
         "node": ">=0.4.0"
       }
-    },
-    "node_modules/promise-nodify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/promise-nodify/-/promise-nodify-1.0.2.tgz",
-      "integrity": "sha1-DQ+xQ8M0ALAGG0flgSV1VwR9TFo="
     },
     "node_modules/prop-types": {
       "version": "15.7.2",
@@ -7134,15 +6910,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/q": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
-      "engines": {
-        "node": ">=0.6.0",
-        "teleport": ">=0.2.0"
       }
     },
     "node_modules/querystring": {
@@ -7383,40 +7150,6 @@
         "node": ">=8.10.0"
       }
     },
-    "node_modules/recast": {
-      "version": "0.11.23",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
-      "integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
-      "dependencies": {
-        "ast-types": "0.9.6",
-        "esprima": "~3.1.0",
-        "private": "~0.1.5",
-        "source-map": "~0.5.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/recast/node_modules/esprima": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-      "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/recast/node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
@@ -7572,7 +7305,8 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "node_modules/saucelabs": {
       "version": "1.5.0",
@@ -7803,6 +7537,7 @@
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
       "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+      "dev": true,
       "dependencies": {
         "amdefine": ">=0.0.4"
       },
@@ -8214,7 +7949,8 @@
     "node_modules/string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
     },
     "node_modules/string-width": {
       "version": "3.1.0",
@@ -8450,7 +8186,8 @@
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
     },
     "node_modules/through2": {
       "version": "3.0.2",
@@ -8533,29 +8270,12 @@
       }
     },
     "node_modules/transform-pouch": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/transform-pouch/-/transform-pouch-1.1.5.tgz",
-      "integrity": "sha512-X8hcWl3GnvSG3QMSBwsvVRCg9yRP3rSQd0wvZx2ZCGtZSrPxxe/l2wsjvETppD48rgA83XycxfPQ2fyOYRMU2w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/transform-pouch/-/transform-pouch-2.0.0.tgz",
+      "integrity": "sha512-nDZovo0U5o0UdMNL93fMQgGjrwH9h4F/a7qqRTnF6cVA+FfgyXiJPTrSuD+LmWSO7r2deZt0P0oeCD8hkgxl5g==",
       "dependencies": {
-        "argsarray": "0.0.1",
-        "es3ify": "0.2.2",
-        "immediate": "~3.0.5",
-        "inherits": "2.0.1",
-        "lie": "3.0.4",
-        "pouchdb-extend": "0.1.2",
-        "pouchdb-promise": "5.4.3",
-        "pouchdb-wrappers": "4.1.0"
+        "pouchdb-wrappers": "^5.0.0"
       }
-    },
-    "node_modules/transform-pouch/node_modules/immediate": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
-    },
-    "node_modules/transform-pouch/node_modules/inherits": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-      "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
     },
     "node_modules/tsconfig-paths": {
       "version": "3.9.0",
@@ -8698,78 +8418,6 @@
         "node": ">= 4.0.0"
       }
     },
-    "node_modules/unreachable-branch-transform": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/unreachable-branch-transform/-/unreachable-branch-transform-0.3.0.tgz",
-      "integrity": "sha1-2ZzExudG0mSSiEW2EdtUsPNHTKo=",
-      "dependencies": {
-        "esmangle-evaluator": "^1.0.0",
-        "recast": "^0.10.1",
-        "through2": "^0.6.2"
-      }
-    },
-    "node_modules/unreachable-branch-transform/node_modules/ast-types": {
-      "version": "0.8.15",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.15.tgz",
-      "integrity": "sha1-ju8IJ/BN/w7IhXupJavj/qYZTlI=",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/unreachable-branch-transform/node_modules/esprima-fb": {
-      "version": "15001.1001.0-dev-harmony-fb",
-      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
-      "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk=",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/unreachable-branch-transform/node_modules/readable-stream": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
-    "node_modules/unreachable-branch-transform/node_modules/recast": {
-      "version": "0.10.43",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.43.tgz",
-      "integrity": "sha1-uV1Q9tYHYaX2JS4V2AZ4FoSRzn8=",
-      "dependencies": {
-        "ast-types": "0.8.15",
-        "esprima-fb": "~15001.1001.0-dev-harmony-fb",
-        "private": "~0.1.5",
-        "source-map": "~0.5.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/unreachable-branch-transform/node_modules/source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/unreachable-branch-transform/node_modules/through2": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-      "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-      "dependencies": {
-        "readable-stream": ">=1.0.33-1 <1.1.0-0",
-        "xtend": ">=4.0.0 <4.1.0-0"
-      }
-    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -8819,7 +8467,6 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.1.0.tgz",
       "integrity": "sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg==",
-      "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -9070,7 +8717,8 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "node_modules/write": {
       "version": "1.0.3",
@@ -9145,6 +8793,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.4"
       }
@@ -9885,7 +9534,8 @@
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true
     },
     "ansi_up": {
       "version": "1.3.0",
@@ -9948,7 +9598,8 @@
     "argsarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/argsarray/-/argsarray-0.0.1.tgz",
-      "integrity": "sha1-bnIHtOzbObCviDA/pa4ivajfYcs="
+      "integrity": "sha1-bnIHtOzbObCviDA/pa4ivajfYcs=",
+      "dev": true
     },
     "array-filter": {
       "version": "1.0.0",
@@ -10045,11 +9696,6 @@
         }
       }
     },
-    "ast-types": {
-      "version": "0.9.6",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
-      "integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk="
-    },
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
@@ -10088,12 +9734,8 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
-    },
-    "base62": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/base62/-/base62-1.2.8.tgz",
-      "integrity": "sha512-V6YHUbjLxN1ymqNLb1DPHoU1CpfdL7d2YTIp5W3U4hhoG4hhxNmsFDs66M9EXxBiSEke5Bt5dwdfMwwZF70iLA=="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "base64-js": {
       "version": "1.5.1",
@@ -10150,6 +9792,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -10777,51 +10420,17 @@
         }
       }
     },
-    "commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-    },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
-    "commoner": {
-      "version": "0.10.8",
-      "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz",
-      "integrity": "sha1-NPw2cs0kOT6LtH5wyqApOBH08sU=",
-      "requires": {
-        "commander": "^2.5.0",
-        "detective": "^4.3.1",
-        "glob": "^5.0.15",
-        "graceful-fs": "^4.1.2",
-        "iconv-lite": "^0.4.5",
-        "mkdirp": "^0.5.0",
-        "private": "^0.1.6",
-        "q": "^1.1.2",
-        "recast": "^0.11.17"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "5.0.15",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
-      }
-    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -10972,7 +10581,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "coverify": {
       "version": "1.5.1",
@@ -11195,7 +10805,8 @@
     "defined": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+      "dev": true
     },
     "dependency-check": {
       "version": "4.1.0",
@@ -11295,22 +10906,6 @@
       "requires": {
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
-      }
-    },
-    "detective": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
-      "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
-      "requires": {
-        "acorn": "^5.2.1",
-        "defined": "^1.0.0"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "5.7.4",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
-          "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg=="
-        }
       }
     },
     "devtools-protocol": {
@@ -11554,23 +11149,6 @@
         "is-callable": "^1.1.4",
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
-      }
-    },
-    "es3ify": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/es3ify/-/es3ify-0.2.2.tgz",
-      "integrity": "sha1-Xa4+ZQ5b42hLiAZlE9Uo0JJimGI=",
-      "requires": {
-        "esprima": "^2.7.1",
-        "jstransform": "~11.0.0",
-        "through": "~2.3.4"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "2.7.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-          "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
-        }
       }
     },
     "es6-error": {
@@ -11901,11 +11479,6 @@
       "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
       "dev": true
     },
-    "esmangle-evaluator": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/esmangle-evaluator/-/esmangle-evaluator-1.0.1.tgz",
-      "integrity": "sha1-Yg2GbvSGGzMR91dm1SqFcrs8YzY="
-    },
     "espree": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
@@ -11930,11 +11503,6 @@
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
-    },
-    "esprima-fb": {
-      "version": "15001.1.0-dev-harmony-fb",
-      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz",
-      "integrity": "sha1-MKlHMDxrjV6VW+4rmbHSMyBqaQE="
     },
     "esquery": {
       "version": "1.4.0",
@@ -12014,24 +11582,6 @@
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
         "yauzl": "^2.10.0"
-      }
-    },
-    "falafel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
-      "integrity": "sha1-wY0k71CRF0pJfzGM0ksCaiXN2rQ=",
-      "requires": {
-        "acorn": "^1.0.3",
-        "foreach": "^2.0.5",
-        "isarray": "0.0.1",
-        "object-keys": "^1.0.6"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz",
-          "integrity": "sha1-yM4n3grMdtiW0rH6099YjZ6C8BQ="
-        }
       }
     },
     "fast-deep-equal": {
@@ -12212,7 +11762,8 @@
     "foreach": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
     },
     "foreground-child": {
       "version": "2.0.0",
@@ -12262,10 +11813,11 @@
       "dev": true
     },
     "garbados-crypt": {
-      "version": "1.0.2-alpha",
-      "resolved": "https://registry.npmjs.org/garbados-crypt/-/garbados-crypt-1.0.2-alpha.tgz",
-      "integrity": "sha512-bvauUqqSvrvIN+JM84OXOBI2u7j6WCtm4+rbdkZAjXBn2gjgvM3bpBLexh4xQYYzHin3ZxUO6DylTQ6+rtCHoQ==",
+      "version": "3.0.0-beta",
+      "resolved": "https://registry.npmjs.org/garbados-crypt/-/garbados-crypt-3.0.0-beta.tgz",
+      "integrity": "sha512-Jw9AnRv4WcfuB7djeBc6IFmXz4VPf14srwvPuoIaOYPfuIibDl7prBC2j0+qL/NPZfwrVZer7h2o6TgGYFoOkA==",
       "requires": {
+        "hash-wasm": "^4.9.0",
         "tweetnacl": "^1.0.3",
         "tweetnacl-util": "^0.15.1"
       }
@@ -12379,7 +11931,8 @@
     "graceful-fs": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "dev": true
     },
     "growl": {
       "version": "1.10.5",
@@ -12446,6 +11999,11 @@
           }
         }
       }
+    },
+    "hash-wasm": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/hash-wasm/-/hash-wasm-4.9.0.tgz",
+      "integrity": "sha512-7SW7ejyfnRxuOc7ptQHSf4LDoZaWOivfzqw+5rpcQku0nHfmicPKE51ra9BiRLAmT8+gGLestr1XroUkqdjL6w=="
     },
     "hash.js": {
       "version": "1.1.7",
@@ -12518,14 +12076,6 @@
         "debug": "4"
       }
     },
-    "iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      }
-    },
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -12570,6 +12120,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -12578,38 +12129,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "inline-process-browser": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/inline-process-browser/-/inline-process-browser-1.0.0.tgz",
-      "integrity": "sha1-RqYbFT3TybFiSxoAYm7bT39BTyI=",
-      "requires": {
-        "falafel": "^1.0.1",
-        "through2": "^0.6.5"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "through2": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-          "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
-          }
-        }
-      }
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "inline-source-map": {
       "version": "0.6.2",
@@ -12905,7 +12426,8 @@
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -13116,25 +12638,6 @@
         "through": ">=2.2.7 <3"
       }
     },
-    "jstransform": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-11.0.3.tgz",
-      "integrity": "sha1-CaeJk+CuTU70SH9hVakfYZDLQiM=",
-      "requires": {
-        "base62": "^1.1.0",
-        "commoner": "^0.10.1",
-        "esprima-fb": "^15001.1.0-dev-harmony-fb",
-        "object-assign": "^2.0.0",
-        "source-map": "^0.4.2"
-      },
-      "dependencies": {
-        "object-assign": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
-          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo="
-        }
-      }
-    },
     "jsx-ast-utils": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.2.0.tgz",
@@ -13295,24 +12798,6 @@
       "requires": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
-      }
-    },
-    "lie": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lie/-/lie-3.0.4.tgz",
-      "integrity": "sha1-vHrh6+fxyN45r9zU94kHa0ew9jQ=",
-      "requires": {
-        "es3ify": "^0.2.2",
-        "immediate": "~3.0.5",
-        "inline-process-browser": "^1.0.0",
-        "unreachable-branch-transform": "^0.3.0"
-      },
-      "dependencies": {
-        "immediate": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-          "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
-        }
       }
     },
     "listen": {
@@ -13546,6 +13031,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -13553,12 +13039,14 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
     },
     "mkdirp": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
       "requires": {
         "minimist": "^1.2.5"
       }
@@ -14354,7 +13842,8 @@
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
     },
     "object.assign": {
       "version": "4.1.2",
@@ -14408,6 +13897,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -14547,7 +14037,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-key": {
       "version": "3.1.1",
@@ -14839,37 +14330,16 @@
         "vuvuzela": "1.0.3"
       }
     },
-    "pouchdb-extend": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/pouchdb-extend/-/pouchdb-extend-0.1.2.tgz",
-      "integrity": "sha1-0c5RG/cE7S4p979CikFqz/+hJLg="
-    },
-    "pouchdb-promise": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/pouchdb-promise/-/pouchdb-promise-5.4.3.tgz",
-      "integrity": "sha1-Mx1nCxmJ1aA/JogRIU8n9UFQyys=",
-      "requires": {
-        "lie": "3.0.4"
-      }
-    },
     "pouchdb-wrappers": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/pouchdb-wrappers/-/pouchdb-wrappers-4.1.0.tgz",
-      "integrity": "sha512-L94K7zgb2tFSvU/iAj1EHK8fC13vKWzzy8kc9HBu9s1jtZSfD34cbWG6qUIvlu61Fso2byp8fsOvp+l5hFiRmg==",
-      "requires": {
-        "promise-nodify": "^1.0.2"
-      }
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pouchdb-wrappers/-/pouchdb-wrappers-5.0.0.tgz",
+      "integrity": "sha512-fXqsVn+rmlPtxaAIGaQP5TkiaT39OMwvMk+ScLLtHrmfXD2KBO6fe/qBl38N/rpTn0h/A058dPN4fLAHt550zA=="
     },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
-    },
-    "private": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg=="
     },
     "process": {
       "version": "0.11.10",
@@ -14897,11 +14367,6 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
-    },
-    "promise-nodify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/promise-nodify/-/promise-nodify-1.0.2.tgz",
-      "integrity": "sha1-DQ+xQ8M0ALAGG0flgSV1VwR9TFo="
     },
     "prop-types": {
       "version": "15.7.2",
@@ -15058,11 +14523,6 @@
           }
         }
       }
-    },
-    "q": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
     },
     "querystring": {
       "version": "0.2.0",
@@ -15259,29 +14719,6 @@
         "picomatch": "^2.2.1"
       }
     },
-    "recast": {
-      "version": "0.11.23",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.23.tgz",
-      "integrity": "sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=",
-      "requires": {
-        "ast-types": "0.9.6",
-        "esprima": "~3.1.0",
-        "private": "~0.1.5",
-        "source-map": "~0.5.0"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-        }
-      }
-    },
     "regexp.prototype.flags": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
@@ -15378,7 +14815,8 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "saucelabs": {
       "version": "1.5.0",
@@ -15563,6 +15001,7 @@
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
       "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+      "dev": true,
       "requires": {
         "amdefine": ">=0.0.4"
       }
@@ -15927,7 +15366,8 @@
     "string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
     },
     "string-width": {
       "version": "3.1.0",
@@ -16119,7 +15559,8 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
     },
     "through2": {
       "version": "3.0.2",
@@ -16189,30 +15630,11 @@
       }
     },
     "transform-pouch": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/transform-pouch/-/transform-pouch-1.1.5.tgz",
-      "integrity": "sha512-X8hcWl3GnvSG3QMSBwsvVRCg9yRP3rSQd0wvZx2ZCGtZSrPxxe/l2wsjvETppD48rgA83XycxfPQ2fyOYRMU2w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/transform-pouch/-/transform-pouch-2.0.0.tgz",
+      "integrity": "sha512-nDZovo0U5o0UdMNL93fMQgGjrwH9h4F/a7qqRTnF6cVA+FfgyXiJPTrSuD+LmWSO7r2deZt0P0oeCD8hkgxl5g==",
       "requires": {
-        "argsarray": "0.0.1",
-        "es3ify": "0.2.2",
-        "immediate": "~3.0.5",
-        "inherits": "2.0.1",
-        "lie": "3.0.4",
-        "pouchdb-extend": "0.1.2",
-        "pouchdb-promise": "5.4.3",
-        "pouchdb-wrappers": "4.1.0"
-      },
-      "dependencies": {
-        "immediate": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-          "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
-        },
-        "inherits": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
-        }
+        "pouchdb-wrappers": "^5.0.0"
       }
     },
     "tsconfig-paths": {
@@ -16332,64 +15754,6 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
     },
-    "unreachable-branch-transform": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/unreachable-branch-transform/-/unreachable-branch-transform-0.3.0.tgz",
-      "integrity": "sha1-2ZzExudG0mSSiEW2EdtUsPNHTKo=",
-      "requires": {
-        "esmangle-evaluator": "^1.0.0",
-        "recast": "^0.10.1",
-        "through2": "^0.6.2"
-      },
-      "dependencies": {
-        "ast-types": {
-          "version": "0.8.15",
-          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.15.tgz",
-          "integrity": "sha1-ju8IJ/BN/w7IhXupJavj/qYZTlI="
-        },
-        "esprima-fb": {
-          "version": "15001.1001.0-dev-harmony-fb",
-          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz",
-          "integrity": "sha1-Q761fsJujPI3092LM+QlM1d/Jlk="
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "recast": {
-          "version": "0.10.43",
-          "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.43.tgz",
-          "integrity": "sha1-uV1Q9tYHYaX2JS4V2AZ4FoSRzn8=",
-          "requires": {
-            "ast-types": "0.8.15",
-            "esprima-fb": "~15001.1001.0-dev-harmony-fb",
-            "private": "~0.1.5",
-            "source-map": "~0.5.0"
-          }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-        },
-        "through2": {
-          "version": "0.6.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-          "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
-          }
-        }
-      }
-    },
     "uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -16440,8 +15804,7 @@
     "uuid": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.1.0.tgz",
-      "integrity": "sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg==",
-      "dev": true
+      "integrity": "sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",
@@ -16647,7 +16010,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "write": {
       "version": "1.0.3",
@@ -16703,7 +16067,8 @@
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true
     },
     "y18n": {
       "version": "5.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "garbados-crypt": "^3.0.0-alpha",
-        "pouchdb-wrappers": "^5.0.0",
         "transform-pouch": "^2.0.0",
         "tweetnacl": "^1.0.3",
         "tweetnacl-util": "^0.15.1",
@@ -6303,9 +6302,9 @@
       }
     },
     "node_modules/path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "node_modules/path-platform": {
@@ -14047,9 +14046,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "path-platform": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   "homepage": "https://github.com/garbados/comdb#readme",
   "dependencies": {
     "garbados-crypt": "^3.0.0-alpha",
-    "pouchdb-wrappers": "^5.0.0",
     "transform-pouch": "^2.0.0",
     "tweetnacl": "^1.0.3",
     "tweetnacl-util": "^0.15.1",

--- a/package.json
+++ b/package.json
@@ -34,10 +34,12 @@
   },
   "homepage": "https://github.com/garbados/comdb#readme",
   "dependencies": {
-    "garbados-crypt": "^1.0.2-alpha",
-    "transform-pouch": "^1.1.5",
+    "garbados-crypt": "^3.0.0-alpha",
+    "pouchdb-wrappers": "^5.0.0",
+    "transform-pouch": "^2.0.0",
     "tweetnacl": "^1.0.3",
-    "tweetnacl-util": "^0.15.1"
+    "tweetnacl-util": "^0.15.1",
+    "uuid": "^8.1.0"
   },
   "devDependencies": {
     "babel-plugin-istanbul": "^6.0.0",

--- a/test.js
+++ b/test.js
@@ -150,6 +150,7 @@ describe('ComDB', function () {
       await this.dbs.decrypted.post({ hello: 'world' })
       await new Promise((resolve) => setTimeout(resolve, 20))
       assert(ok)
+      changes.cancel()
     })
   })
 
@@ -181,17 +182,17 @@ describe('ComDB', function () {
 
   describe('replication', function () {
     beforeEach(async function () {
-      this.name2 = [this.name, '2'].join('-')
+      this.name2 = [this.name, 'replication', '2'].join('-')
       this.db2 = new PouchDB(this.name2)
       const keyDoc = await this.db.get('_local/comdb')
       delete keyDoc._rev
       await this.db2.put(keyDoc) // share keys
       await this.db2.setPassword(this.password)
-      return this.db.post({ hello: 'sol' })
+      await this.db.post({ hello: 'sol' })
     })
 
-    afterEach(function () {
-      return this.db2.destroy()
+    afterEach(async function () {
+      await this.db2.destroy()
     })
 
     it('should restore data from an encrypted backup', async function () {


### PR DESCRIPTION
This PR refactors ComDB's internals to support the latest versions of transform-pouch and garbados-crypt. It also adds a `.loadDecrypted` method and allows the use of options with `.loadDecrypted` and `.loadEncrypted`. The readme has been updated appropriately.