### PR TITLE
Fix e2e

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,38 @@ ComDB wraps PouchDB's database destruction method so that both the encrypted and
 
 Original: [db.destroy()](https://pouchdb.com/api.html#delete_database)
 
+### `async db.exportComDB()`
+
+Export the encryption key specific to your database's encrypted copy. This is necessary to creating new encrypted copies that can still replicate with the original, for example if you're creating an encrypted copy on a phone by replicating down from a server.
+
+```javascript
+// on one machine
+const db1 = new PouchDB('device-1')
+await db1.setPassword(password)
+const key = await db1.exportComDB()
+// then, on another
+const db2 = new PouchDB('device-2')
+await db2.importComDB(password, key)
+// now db2 can replicate with db1
+await PouchDB.sync(db1, db2)
+```
+
+### `async db.importComDB(password, encryptionKey)`
+
+Set up ComDB, like `db.setPassword()`, but rather than generating a new encryption key for your encrypted copy, ComDB will use the given one. This allows you to replicate with other encrypted databases using the same password and encryption key.
+
+```javascript
+// on one machine
+const db1 = new PouchDB('device-1')
+await db1.setPassword(password)
+const key = await db1.exportComDB()
+// then, on another
+const db2 = new PouchDB('device-2')
+await db2.importComDB(password, key)
+// now db2 can replicate with db1
+await PouchDB.sync(db1, db2)
+```
+
 ### `async db.loadEncrypted(opts = {})`
 
 Load changes from the encrypted database into the decrypted one. Useful if you are restoring from backup:
@@ -213,9 +245,8 @@ db.setPassword(PASSWORD).then(async () => {
 You can then replicate your encrypted database with a remote CouchDB installation to ensure you can restore your data even if your device is compromised:
 
 ```javascript
-// create remote db connection
-const remoteDb = new PouchDB('http://...') // CouchDB connection string
 // sync local encrypted with remote
+const remoteDb = 'https://...' // CouchDB url
 const sync = PouchDB.sync(db, remoteDb, { live: true, retry: true })
 ```
 

--- a/examples/couchdb.js
+++ b/examples/couchdb.js
@@ -8,28 +8,22 @@ PouchDB.plugin(require('..'))
 
 const COUCH_URL = process.env.COUCH_URL || 'http://localhost:5984'
 assert(COUCH_URL, 'This example requires that $COUCH_URL be set to a URL for accessing a CouchDB instance.')
+const COUCH_DB_URL = `${COUCH_URL}/comdb-example`
 
 const password = 'scarcity-is-artificial'
 
 // create the database and set a password
 const db = new PouchDB('.comdb-example')
-let db2
+let db2, db3
 
 Promise.resolve().then(async () => {
   console.log(`
-When you set a password for ComDB, it creates an encrypted database
-that maps changes to and from your database. In this example, the
-encrypted database exists on a CouchDB instance, while the decrypted
-one lives on disk.
+When you set a password for ComDB, it creates an encrypted database that maps changes to and from your database. In this example, the encrypted database exists on a CouchDB instance, while the decrypted one lives on disk.
   `)
-  await db.setPassword(password, {
-    name: [COUCH_URL, 'comdb-example'].join('/')
-  })
+  await db.setPassword(password, { name: COUCH_DB_URL })
   const { id } = await db.post({ greetings: 'hello world' })
   const doc = await db.get(id)
-  console.log(`Documents are decrypted so that you can maintain indexes on them.
-The database's methods, except for replication, refer to the
-decrypted database. Here is a decrypted document retrieved by ID:
+  console.log(`Documents are decrypted so that you can maintain indexes on them. The database's methods, except for replication, refer to the decrypted database. Here is a decrypted document retrieved by ID:
   `)
   assert.strictEqual(doc.greetings, 'hello world')
   console.log(doc)
@@ -39,9 +33,7 @@ decrypted database. Here is a decrypted document retrieved by ID:
   const doc = rows[0].doc
   // this doc lives in couchdb and is encrypted
   console.log(`
-... and here is that document, encrypted!
-This document lives in CouchDB such that your decrypted data never
-leaves the local machine.
+The encrypted document lives in CouchDB such that your decrypted data never leaves the local machine. Here's how the encrypted version looks:
   `)
   console.log(doc)
   const { _id: id } = JSON.parse(await db._crypt.decrypt(doc.payload))
@@ -53,33 +45,36 @@ Here is the payload from that document, decrypted:
   console.log(doc)
 }).then(async () => {
   console.log(`
-You can even create a different database and replicate encrypted
-data to it. As long as you provide the second instance with the same
-password, it will transparently decrypt replicated documents. Now I
-will replicate our first database to our second...
+You can even create a different decrypted database and replicate encrypted data to it. As long as you are using the same encrypted copy, you can do this with just a password.
+
+But perhaps you are maintaining a separate encrypted copy, such as on another device. Then you will need to export your encryption key. First, use \`db.exportComDB()\` to get your encryption key, and then on another device use \`db.importComDB()\` to set up encryption. As long as you provide the second instance with the same password and encryption key, it will transparently decrypt replicated documents. Now I will replicate our first database to our second...
   `)
   db2 = new PouchDB('.comdb-example-2')
-  const keyDoc = await db.get('_local/comdb')
-  delete keyDoc._rev
-  await db2.put(keyDoc)
-  await db2.setPassword(password)
-  await db.replicate.to(db2)
-  const { rows } = await db2.allDocs({ include_docs: true, limit: 1 })
-  const { doc } = rows[0]
+  // set up encryption to use a pre-existing encrypted copy
+  await db2.setPassword(password, { name: COUCH_DB_URL }) // use same encrypted copy
+  await db2.loadEncrypted() // load encrypted docs from pre-existing copy
+  const { rows: [{ doc }] } = await db2.allDocs({ include_docs: true, limit: 1 })
   const otherDoc = await db.get(doc._id)
   assert(isEqual(doc, otherDoc))
+  // set up encryption to replicate from a pre-existing encrypted copy
+  const key = await db2.exportComDB() // get this on one device...
+  db3 = new PouchDB('.comdb-example-3')
+  await db3.importComDB(password, key) // then use it to set up encryption on another
+  await db3.replicate.from(COUCH_DB_URL)
+  const { rows: [{ doc: doc2 }] } = await db3.allDocs({ include_docs: true, limit: 1 })
+  assert(isEqual(doc2, otherDoc))
   console.log(`... replication successful!
 
-The second database, using the password, has automatically decrypted
-the remote documents. The encrypted version remains on the server,
-unchanged.
+The second database, using the password, has automatically decrypted the remote documents. The encrypted version remains on the server, unchanged.
   `)
 }).then(() => {
   console.log(`Cool, huh?
   `)
 }).catch((error) => {
+  console.error('Something has gone wrong in an example! You should report this as a bug.')
   console.error(error)
 }).then(async () => {
   await db.destroy()
   if (db2) { await db2.destroy() }
+  if (db3) { await db3.destroy() }
 })

--- a/examples/couchdb.js
+++ b/examples/couchdb.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 'use strict'
 
+console.log('# Using ComDB with CouchDB')
+
 const isEqual = require('lodash.isequal')
 const assert = require('assert')
 const PouchDB = require('pouchdb')

--- a/examples/e2e.js
+++ b/examples/e2e.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+'use strict'
+
+const assert = require('assert')
+const PouchDB = require('pouchdb')
+PouchDB.plugin(require('pouchdb-adapter-memory'))
+PouchDB.plugin(require('..'))
+
+const NAME = '.comdb-example'
+const ID = 'example'
+const PASSWORD = 'do-not-allow-fear-to-goad-you-into-a-life-of-regret'
+
+Promise.resolve().then(async () => {
+  // create an in-memory database
+  const db = new PouchDB(NAME, { adapter: 'memory' })
+  // create an encrypted on-disk copy
+  await db.setPassword(PASSWORD)
+  // write a doc
+  await db.put({ _id: ID })
+  // destroy the unencrypted copy
+  await db.destroy({ unencrypted_only: true })
+  // user restarts app, refresh the page, etc.
+  const db2 = new PouchDB(NAME, { adapter: 'memory' })
+  // set your password normally. it accesses the same encrypted on-disk copy
+  await db2.setPassword(PASSWORD)
+  // load documents from the encrypted copy
+  await db2.loadEncrypted()
+  // get the doc
+  const doc = await db2.get(ID)
+  // it's the same one
+  assert.equal(doc._id, ID)
+  // clean up
+  await db2.destroy()
+  // thank you for reading
+  console.log('done')
+}).catch((err) => {
+  console.error('Something has gone wrong in an example! You should report this as a bug.')
+  console.error(err)
+})

--- a/examples/e2e.js
+++ b/examples/e2e.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 'use strict'
 
+console.log('# Achieving E2E encryption with ComDB')
+
 const assert = require('assert')
 const PouchDB = require('pouchdb')
 PouchDB.plugin(require('pouchdb-adapter-memory'))
@@ -29,7 +31,7 @@ enables the 'memory' adapter.
 When you write and read documents, you will be interacting with the decrypted
 database, and thus these operations will be relatively fast.
 
-Let's write a document to our in-memory database.
+Let's write some documents to our in-memory database.
     `)
   // write a lot of docs
   const startTime = Date.now()

--- a/examples/e2e.js
+++ b/examples/e2e.js
@@ -9,31 +9,80 @@ PouchDB.plugin(require('..'))
 const NAME = '.comdb-example'
 const ID = 'example'
 const PASSWORD = 'do-not-allow-fear-to-goad-you-into-a-life-of-regret'
+const NUM_DOCS = 1e3
+
+let db, db2
 
 Promise.resolve().then(async () => {
+  console.log(`
+You can achieve end-to-end encryption with ComDB by making your decrypted copy
+exist only in memory. Thus, only your encrypted copy is ever written to disk.
+
+In PouchDB, you can do this with the 'pouchdb-adapter-memory' module, which
+enables the 'memory' adapter.
+    `)
   // create an in-memory database
-  const db = new PouchDB(NAME, { adapter: 'memory' })
+  db = new PouchDB(NAME, { adapter: 'memory' })
   // create an encrypted on-disk copy
   await db.setPassword(PASSWORD)
-  // write a doc
-  await db.put({ _id: ID })
+  console.log(`
+When you write and read documents, you will be interacting with the decrypted
+database, and thus these operations will be relatively fast.
+
+Let's write a document to our in-memory database.
+    `)
+  // write a lot of docs
+  const startTime = Date.now()
+  const docs = [{ _id: ID }]
+  for (let i = 0; i < NUM_DOCS; i++) {
+    docs.push({ _id: `${ID}-${i}` })
+  }
+  await db.bulkDocs(docs)
+  const endTime = Date.now()
   // destroy the unencrypted copy
   await db.destroy({ unencrypted_only: true })
+  console.log(`
+Writing ${NUM_DOCS + 1} documents took ${endTime - startTime}ms.
+
+If you are using an in-memory PouchDB in a browser, then it will be wiped out
+whenever you reload the page. By loading from the same encrypted copy, you can
+restore your data.
+    `)
+}).then(async () => {
   // user restarts app, refresh the page, etc.
-  const db2 = new PouchDB(NAME, { adapter: 'memory' })
+  db2 = new PouchDB(NAME, { adapter: 'memory' })
   // set your password normally. it accesses the same encrypted on-disk copy
   await db2.setPassword(PASSWORD)
+  console.log(`
+Because the encrypted copy must be decrypted entirely each time the page refreshes,
+this approach imposes a significant startup time.
+    `)
   // load documents from the encrypted copy
+  const startTime = Date.now() // time how long it takes to set up
   await db2.loadEncrypted()
+  const endTime = Date.now()
   // get the doc
   const doc = await db2.get(ID)
   // it's the same one
   assert.equal(doc._id, ID)
+  console.log(`
+For a database with ${NUM_DOCS + 1} documents, initialization took ${endTime - startTime}ms.
+    `)
   // clean up
   await db2.destroy()
   // thank you for reading
-  console.log('done')
+  console.log(`
+And that's all there is to it!
+    `)
 }).catch((err) => {
   console.error('Something has gone wrong in an example! You should report this as a bug.')
   console.error(err)
+}).then(async () => {
+  for (const d of [db, db2]) {
+    try {
+      await d.destroy()
+    } catch (err) {
+      // ignore
+    }
+  }
 })

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const transform = require('transform-pouch')
 const { hash: naclHash } = require('tweetnacl')
 const { decodeUTF8, encodeBase64 } = require('tweetnacl-util')
 const { v4: uuid } = require('uuid')
+const { stringMd5 } = require('pouchdb-md5')
 
 const PASSWORD_REQUIRED = 'You must provide a password.'
 const PASSWORD_NOT_STRING = 'Password must be a string.'
@@ -49,50 +50,15 @@ module.exports = function (PouchDB) {
     return promise
   }
 
-  // setup function; must call before anything works
-  PouchDB.prototype.setPassword = async function (password, opts = {}) {
-    if (!password) { throw new Error(PASSWORD_REQUIRED) }
-    if (typeof password !== 'string') { throw new Error(PASSWORD_NOT_STRING) }
-    this._password = password
-    const trySetup = async () => {
-      // try saving credentials to a local doc
-      try {
-        // first we try to get saved creds from the local doc
-        const { exportString } = await this.get(LOCAL_ID)
-        this._crypt = await Crypt.import(password, exportString)
-      } catch (err) {
-        // istanbul ignore else
-        if (err.status === 404) {
-          // but if the doc doesn't exist, we do first-time setup
-          this._crypt = new Crypt(password)
-          const exportString = await this._crypt.export()
-          try {
-            await this.put({ _id: LOCAL_ID, exportString })
-          } catch (err2) {
-            // istanbul ignore else
-            if (err2.status === 409) {
-              // if the doc was created while we were setting up,
-              // try setting up again to retrieve the saved credentials.
-              await trySetup()
-            } else {
-              throw err2
-            }
-          }
-        } else {
-          throw err
-        }
-      }
-    }
-    await trySetup()
-    const encryptedName = opts.name || `${this.name}-encrypted`
-    const encryptedOpts = opts.opts || {}
-    this._encrypted = new PouchDB(encryptedName, encryptedOpts)
-    this._encrypted.transform({
+  function setupEncrypted (name, opts = {}) {
+    const db = new PouchDB(name, opts)
+
+    db.transform({
       // encrypt docs as they go in
       incoming: async (doc) => {
         if (doc.isEncrypted) {
           // feed already-encrypted docs back to the decrypted db
-          await this.bulkDocs([doc])
+          await this.bulkDocs([doc], { new_edits: false })
           return doc
         } else {
           // encrypt the doc
@@ -109,33 +75,22 @@ module.exports = function (PouchDB) {
         }
       }
     })
+
+    return db
+  }
+
+  function setupDecrypted () {
     this.transform({
       incoming: async (doc) => {
         if (doc.isEncrypted) {
           // decrypt encrypted payloads being fed back from the encrypted db
           const json = await this._crypt.decrypt(doc.payload)
           const decrypted = JSON.parse(json)
-          if ('_rev' in decrypted) {
-            return decrypted
-          } else {
-            // decrypted doc has no rev. there might already be one in the db
-            // so we have to check for it.
-            try {
-              const { _revisions: { ids } } = await this.get(decrypted._id, { revs: true })
-              decrypted._rev = `1-${ids[ids.length - 1]}`
-            } catch (err) {
-              if (err.name === 'not_found') {
-                // return the rev-less doc if no rev exists for it
-                return decrypted
-              } else {
-                throw err
-              }
-            }
-            // original doc lacks _rev, so apply it back now that we know it
-            doc.payload = await this._crypt.encrypt(JSON.stringify(decrypted))
-            await this._encrypted.put(doc)
-            return decrypted
+          if (!('_rev' in decrypted)) {
+            // construct an artificial rev, predicting what it will be
+            decrypted._rev = `1-${stringMd5(JSON.stringify(decrypted))}`
           }
+          return decrypted
         } else {
           if (!doc._id) doc._id = uuid()
           await this._encrypted.bulkDocs([doc])
@@ -143,6 +98,88 @@ module.exports = function (PouchDB) {
         }
       }
     })
+  }
+
+  async function setupComDB (password) {
+    // try saving credentials to a local doc
+    try {
+      // first we try to get saved creds from the local doc
+      const { exportString } = await this._encrypted.get(LOCAL_ID)
+      this._crypt = await Crypt.import(password, exportString)
+    } catch (err) {
+      // istanbul ignore else
+      if (err.status === 404) {
+        // but if the doc doesn't exist, we do first-time setup
+        this._crypt = new Crypt(password)
+        const exportString = await this._crypt.export()
+        try {
+          await this._encrypted.put({ _id: LOCAL_ID, exportString })
+        } catch (err2) {
+          // istanbul ignore else
+          if (err2.status === 409) {
+            // if the doc was created while we were setting up,
+            // try setting up again to retrieve the saved credentials.
+            await setupComDB.call(this, password)
+          } else {
+            throw err2
+          }
+        }
+      } else {
+        throw err
+      }
+    }
+  }
+
+  async function importComDB (password, exportString) {
+    this._crypt = await Crypt.import(password, exportString)
+    try {
+      await this._encrypted.put({ _id: LOCAL_ID, exportString })
+    } catch (err) {
+      // istanbul ignore if
+      if (err.status !== 409) {
+        throw err
+      }
+    }
+  }
+
+  function parseEncryptedOpts (opts = {}) {
+    return [
+      opts.name || `${this.name}-encrypted`,
+      opts.opts || {}
+    ]
+  }
+
+  // setup function; must call before anything works
+  PouchDB.prototype.setPassword = async function (password, opts = {}) {
+    if (!password) { throw new Error(PASSWORD_REQUIRED) }
+    if (typeof password !== 'string') { throw new Error(PASSWORD_NOT_STRING) }
+    this._password = password
+    const [encryptedName, encryptedOpts] = parseEncryptedOpts.call(this, opts)
+    this._encrypted = setupEncrypted.call(this, encryptedName, encryptedOpts)
+    setupDecrypted.call(this)
+    await setupComDB.call(this, password)
+  }
+
+  PouchDB.prototype.importComDB = async function (password, exportString, opts = {}) {
+    if (!password) { throw new Error(PASSWORD_REQUIRED) }
+    if (typeof password !== 'string') { throw new Error(PASSWORD_NOT_STRING) }
+    if (!exportString) { throw new Error('TODO') }
+    if (typeof exportString !== 'string') { throw new Error('TODO') }
+    this._password = password
+    const [encryptedName, encryptedOpts] = parseEncryptedOpts.call(this, opts)
+    this._encrypted = setupEncrypted.call(this, encryptedName, encryptedOpts)
+    setupDecrypted.call(this)
+    await importComDB.call(this, password, exportString)
+  }
+
+  PouchDB.prototype.exportComDB = async function () {
+    const { exportString } = await this._encrypted.get(LOCAL_ID)
+    return exportString
+  }
+
+  PouchDB.prototype.getComDB = function (opts = {}) {
+    const [encryptedName, encryptedOpts] = parseEncryptedOpts.call(this, opts)
+    return new PouchDB(encryptedName, encryptedOpts)
   }
 
   // load from encrypted db, to catch up to offline writes

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ module.exports = function (PouchDB) {
       if (source._encrypted) source = source._encrypted
       if (target._encrypted) target = target._encrypted
     }
-    return replicate(source, target, opts)
+    return replicate.call(this, source, target, opts)
   }
 
   // apply instance method wrappers
@@ -52,7 +52,7 @@ module.exports = function (PouchDB) {
     return promise
   }
 
-  function setupEncrypted (name, opts = {}) {
+  function setupEncrypted (name, opts) {
     const db = new PouchDB(name, opts)
 
     db.transform({
@@ -137,21 +137,21 @@ module.exports = function (PouchDB) {
     try {
       await this._encrypted.put({ _id: LOCAL_ID, exportString })
     } catch (err) {
-      // istanbul ignore if
+      // istanbul ignore next
       if (err.status !== 409) {
         throw err
       }
     }
   }
 
-  function parseEncryptedOpts (opts = {}) {
+  function parseEncryptedOpts (opts) {
     return [
       opts.name || `${this.name}-encrypted`,
       opts.opts || {}
     ]
   }
 
-  function setupComDB (opts = {}) {
+  function setupComDB (opts) {
     const [encryptedName, encryptedOpts] = parseEncryptedOpts.call(this, opts)
     this._encrypted = setupEncrypted.call(this, encryptedName, encryptedOpts)
     setupDecrypted.call(this)
@@ -177,11 +177,6 @@ module.exports = function (PouchDB) {
   PouchDB.prototype.exportComDB = async function () {
     const { exportString } = await this._encrypted.get(LOCAL_ID)
     return exportString
-  }
-
-  PouchDB.prototype.getComDB = function (opts = {}) {
-    const [encryptedName, encryptedOpts] = parseEncryptedOpts.call(this, opts)
-    return new PouchDB(encryptedName, encryptedOpts)
   }
 
   // load from encrypted db, to catch up to offline writes

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "garbados-crypt": "^3.0.0-alpha",
+        "pouchdb-md5": "^7.3.0",
         "transform-pouch": "^2.0.0",
         "tweetnacl": "^1.0.3",
         "tweetnacl-util": "^0.15.1",
@@ -25,6 +26,7 @@
         "mochify": "^9.2.0",
         "nyc": "^15.1.0",
         "pouchdb": "^7.3.0",
+        "pouchdb-adapter-memory": "^7.3.0",
         "standard": "^17.0.0",
         "uglify-js": "^3.15.4"
       }
@@ -1540,8 +1542,7 @@
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "node_modules/buffer-xor": {
       "version": "1.0.3",
@@ -5015,6 +5016,35 @@
         "safe-buffer": "^5.1.2"
       }
     },
+    "node_modules/memdown": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
+      "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
+      "dev": true,
+      "dependencies": {
+        "abstract-leveldown": "~2.7.1",
+        "functional-red-black-tree": "^1.0.1",
+        "immediate": "^3.2.3",
+        "inherits": "~2.0.1",
+        "ltgt": "~2.2.0",
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "node_modules/memdown/node_modules/abstract-leveldown": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
+      "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
+      "dev": true,
+      "dependencies": {
+        "xtend": "~4.0.0"
+      }
+    },
+    "node_modules/memdown/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -6513,6 +6543,116 @@
         "vuvuzela": "1.0.3"
       }
     },
+    "node_modules/pouchdb-adapter-leveldb-core": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/pouchdb-adapter-leveldb-core/-/pouchdb-adapter-leveldb-core-7.3.0.tgz",
+      "integrity": "sha512-OyUsEae1JlqR2jSGMohP03gj6VANh9fDR/3nPIa1vYyoQWlwQzOS7knKqDaJm7Nui3JC5q/lWos7/FGZBFuF5Q==",
+      "dev": true,
+      "dependencies": {
+        "argsarray": "0.0.1",
+        "buffer-from": "1.1.2",
+        "double-ended-queue": "2.1.0-0",
+        "levelup": "4.4.0",
+        "pouchdb-adapter-utils": "7.3.0",
+        "pouchdb-binary-utils": "7.3.0",
+        "pouchdb-collections": "7.3.0",
+        "pouchdb-errors": "7.3.0",
+        "pouchdb-json": "7.3.0",
+        "pouchdb-md5": "7.3.0",
+        "pouchdb-merge": "7.3.0",
+        "pouchdb-utils": "7.3.0",
+        "sublevel-pouchdb": "7.3.0",
+        "through2": "3.0.2"
+      }
+    },
+    "node_modules/pouchdb-adapter-memory": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/pouchdb-adapter-memory/-/pouchdb-adapter-memory-7.3.0.tgz",
+      "integrity": "sha512-nUdYi5KpbUa0uv0L3IJorpiUnIOBPxX9qplCX9i7JE8OtLPeLyKuX3WC+3M1//8Lmmxg3b1wXSNIod6FJy4wAQ==",
+      "dev": true,
+      "dependencies": {
+        "memdown": "1.4.1",
+        "pouchdb-adapter-leveldb-core": "7.3.0",
+        "pouchdb-utils": "7.3.0"
+      }
+    },
+    "node_modules/pouchdb-adapter-utils": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/pouchdb-adapter-utils/-/pouchdb-adapter-utils-7.3.0.tgz",
+      "integrity": "sha512-mU1+smcagWSpInVx/VQk7VVjjnJlyagKtusUS3OdCMFZY35L6RbXC8eIhoNVDbkBfEv3cIwqQ3t7fdvkaa1odQ==",
+      "dev": true,
+      "dependencies": {
+        "pouchdb-binary-utils": "7.3.0",
+        "pouchdb-collections": "7.3.0",
+        "pouchdb-errors": "7.3.0",
+        "pouchdb-md5": "7.3.0",
+        "pouchdb-merge": "7.3.0",
+        "pouchdb-utils": "7.3.0"
+      }
+    },
+    "node_modules/pouchdb-binary-utils": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/pouchdb-binary-utils/-/pouchdb-binary-utils-7.3.0.tgz",
+      "integrity": "sha512-xvBH/XGHGcou2vkEzszJxkCc7YElfRUrkLUg51Jbdmh1mogLDUO0bU3Tj6TOIIJfRkQrU/HV+dDkMAhsil0amQ==",
+      "dependencies": {
+        "buffer-from": "1.1.2"
+      }
+    },
+    "node_modules/pouchdb-collections": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/pouchdb-collections/-/pouchdb-collections-7.3.0.tgz",
+      "integrity": "sha512-Xr54m2+fErShXn+qAT4xwqJ+8NwddNPeTMJT4z4k1sZsrwfHmZsWbsKAyGPMF04eQaaU+7DDRMciu2VzaBUXyg==",
+      "dev": true
+    },
+    "node_modules/pouchdb-errors": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/pouchdb-errors/-/pouchdb-errors-7.3.0.tgz",
+      "integrity": "sha512-dTBbIC1BbCy6J9W/Csg5xROgb3wJN3HpbgAJHHSEtAkb8oA45KZmU3ZwEpNhf0AfPuQm4XgW1936PvlDlGgJiw==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "2.0.4"
+      }
+    },
+    "node_modules/pouchdb-json": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/pouchdb-json/-/pouchdb-json-7.3.0.tgz",
+      "integrity": "sha512-D4wyi20ltyiFpuziQeMk3CbXs/Q58VoGTYTJQY8MWBw37OidtHGQAt1Kh5yJ435wJqDzJZyxMA5RxGZxEOBDVg==",
+      "dev": true,
+      "dependencies": {
+        "vuvuzela": "1.0.3"
+      }
+    },
+    "node_modules/pouchdb-md5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/pouchdb-md5/-/pouchdb-md5-7.3.0.tgz",
+      "integrity": "sha512-wL04QgoKyd/L/TV5gxgcvlEyCJiZoXCOEFJklTzkdza/kBQNJGPH7i0ZhKa7Sb+AvZYoWZHddf1Zgv7rBScHkA==",
+      "dependencies": {
+        "pouchdb-binary-utils": "7.3.0",
+        "spark-md5": "3.0.2"
+      }
+    },
+    "node_modules/pouchdb-merge": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/pouchdb-merge/-/pouchdb-merge-7.3.0.tgz",
+      "integrity": "sha512-E7LmchMzwYFm6V8OBxejzARLisanpksOju2LEfuiYnotGfNDeW7MByP0qBH0/zF8BfUyyjA1cl7ByaEpsapkeQ==",
+      "dev": true
+    },
+    "node_modules/pouchdb-utils": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/pouchdb-utils/-/pouchdb-utils-7.3.0.tgz",
+      "integrity": "sha512-HH+5IXXWn/ZgVCSnrlydBMYn6MabT7RS7SNoo9w8qVH9efpZSp3eLchw6yMQNLw8LQefWmbbskiHV9VgJmSVWQ==",
+      "dev": true,
+      "dependencies": {
+        "argsarray": "0.0.1",
+        "clone-buffer": "1.0.0",
+        "immediate": "3.3.0",
+        "inherits": "2.0.4",
+        "pouchdb-collections": "7.3.0",
+        "pouchdb-errors": "7.3.0",
+        "pouchdb-md5": "7.3.0",
+        "uuid": "8.3.2"
+      }
+    },
     "node_modules/pouchdb-wrappers": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/pouchdb-wrappers/-/pouchdb-wrappers-5.0.0.tgz",
@@ -7223,8 +7363,7 @@
     "node_modules/spark-md5": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.2.tgz",
-      "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==",
-      "dev": true
+      "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw=="
     },
     "node_modules/spawn-wrap": {
       "version": "2.0.0",
@@ -7628,6 +7767,18 @@
       "dev": true,
       "dependencies": {
         "minimist": "^1.1.0"
+      }
+    },
+    "node_modules/sublevel-pouchdb": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/sublevel-pouchdb/-/sublevel-pouchdb-7.3.0.tgz",
+      "integrity": "sha512-zp7u4jmv2N/s+dXZkWTtL4BjREs3SZ1nGBNNJ8RWX4yqN59oHgKmti4CfVOqfsAW9RMasmTqQAEPxL9hX8+CIA==",
+      "dev": true,
+      "dependencies": {
+        "inherits": "2.0.4",
+        "level-codec": "9.0.2",
+        "ltgt": "2.2.1",
+        "readable-stream": "1.1.14"
       }
     },
     "node_modules/supports-color": {
@@ -9726,8 +9877,7 @@
     "buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -12464,6 +12614,37 @@
         "safe-buffer": "^5.1.2"
       }
     },
+    "memdown": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/memdown/-/memdown-1.4.1.tgz",
+      "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
+      "dev": true,
+      "requires": {
+        "abstract-leveldown": "~2.7.1",
+        "functional-red-black-tree": "^1.0.1",
+        "immediate": "^3.2.3",
+        "inherits": "~2.0.1",
+        "ltgt": "~2.2.0",
+        "safe-buffer": "~5.1.1"
+      },
+      "dependencies": {
+        "abstract-leveldown": {
+          "version": "2.7.2",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
+          "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
+          "dev": true,
+          "requires": {
+            "xtend": "~4.0.0"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
+      }
+    },
     "merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -13689,6 +13870,116 @@
         "vuvuzela": "1.0.3"
       }
     },
+    "pouchdb-adapter-leveldb-core": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/pouchdb-adapter-leveldb-core/-/pouchdb-adapter-leveldb-core-7.3.0.tgz",
+      "integrity": "sha512-OyUsEae1JlqR2jSGMohP03gj6VANh9fDR/3nPIa1vYyoQWlwQzOS7knKqDaJm7Nui3JC5q/lWos7/FGZBFuF5Q==",
+      "dev": true,
+      "requires": {
+        "argsarray": "0.0.1",
+        "buffer-from": "1.1.2",
+        "double-ended-queue": "2.1.0-0",
+        "levelup": "4.4.0",
+        "pouchdb-adapter-utils": "7.3.0",
+        "pouchdb-binary-utils": "7.3.0",
+        "pouchdb-collections": "7.3.0",
+        "pouchdb-errors": "7.3.0",
+        "pouchdb-json": "7.3.0",
+        "pouchdb-md5": "7.3.0",
+        "pouchdb-merge": "7.3.0",
+        "pouchdb-utils": "7.3.0",
+        "sublevel-pouchdb": "7.3.0",
+        "through2": "3.0.2"
+      }
+    },
+    "pouchdb-adapter-memory": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/pouchdb-adapter-memory/-/pouchdb-adapter-memory-7.3.0.tgz",
+      "integrity": "sha512-nUdYi5KpbUa0uv0L3IJorpiUnIOBPxX9qplCX9i7JE8OtLPeLyKuX3WC+3M1//8Lmmxg3b1wXSNIod6FJy4wAQ==",
+      "dev": true,
+      "requires": {
+        "memdown": "1.4.1",
+        "pouchdb-adapter-leveldb-core": "7.3.0",
+        "pouchdb-utils": "7.3.0"
+      }
+    },
+    "pouchdb-adapter-utils": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/pouchdb-adapter-utils/-/pouchdb-adapter-utils-7.3.0.tgz",
+      "integrity": "sha512-mU1+smcagWSpInVx/VQk7VVjjnJlyagKtusUS3OdCMFZY35L6RbXC8eIhoNVDbkBfEv3cIwqQ3t7fdvkaa1odQ==",
+      "dev": true,
+      "requires": {
+        "pouchdb-binary-utils": "7.3.0",
+        "pouchdb-collections": "7.3.0",
+        "pouchdb-errors": "7.3.0",
+        "pouchdb-md5": "7.3.0",
+        "pouchdb-merge": "7.3.0",
+        "pouchdb-utils": "7.3.0"
+      }
+    },
+    "pouchdb-binary-utils": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/pouchdb-binary-utils/-/pouchdb-binary-utils-7.3.0.tgz",
+      "integrity": "sha512-xvBH/XGHGcou2vkEzszJxkCc7YElfRUrkLUg51Jbdmh1mogLDUO0bU3Tj6TOIIJfRkQrU/HV+dDkMAhsil0amQ==",
+      "requires": {
+        "buffer-from": "1.1.2"
+      }
+    },
+    "pouchdb-collections": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/pouchdb-collections/-/pouchdb-collections-7.3.0.tgz",
+      "integrity": "sha512-Xr54m2+fErShXn+qAT4xwqJ+8NwddNPeTMJT4z4k1sZsrwfHmZsWbsKAyGPMF04eQaaU+7DDRMciu2VzaBUXyg==",
+      "dev": true
+    },
+    "pouchdb-errors": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/pouchdb-errors/-/pouchdb-errors-7.3.0.tgz",
+      "integrity": "sha512-dTBbIC1BbCy6J9W/Csg5xROgb3wJN3HpbgAJHHSEtAkb8oA45KZmU3ZwEpNhf0AfPuQm4XgW1936PvlDlGgJiw==",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.4"
+      }
+    },
+    "pouchdb-json": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/pouchdb-json/-/pouchdb-json-7.3.0.tgz",
+      "integrity": "sha512-D4wyi20ltyiFpuziQeMk3CbXs/Q58VoGTYTJQY8MWBw37OidtHGQAt1Kh5yJ435wJqDzJZyxMA5RxGZxEOBDVg==",
+      "dev": true,
+      "requires": {
+        "vuvuzela": "1.0.3"
+      }
+    },
+    "pouchdb-md5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/pouchdb-md5/-/pouchdb-md5-7.3.0.tgz",
+      "integrity": "sha512-wL04QgoKyd/L/TV5gxgcvlEyCJiZoXCOEFJklTzkdza/kBQNJGPH7i0ZhKa7Sb+AvZYoWZHddf1Zgv7rBScHkA==",
+      "requires": {
+        "pouchdb-binary-utils": "7.3.0",
+        "spark-md5": "3.0.2"
+      }
+    },
+    "pouchdb-merge": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/pouchdb-merge/-/pouchdb-merge-7.3.0.tgz",
+      "integrity": "sha512-E7LmchMzwYFm6V8OBxejzARLisanpksOju2LEfuiYnotGfNDeW7MByP0qBH0/zF8BfUyyjA1cl7ByaEpsapkeQ==",
+      "dev": true
+    },
+    "pouchdb-utils": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/pouchdb-utils/-/pouchdb-utils-7.3.0.tgz",
+      "integrity": "sha512-HH+5IXXWn/ZgVCSnrlydBMYn6MabT7RS7SNoo9w8qVH9efpZSp3eLchw6yMQNLw8LQefWmbbskiHV9VgJmSVWQ==",
+      "dev": true,
+      "requires": {
+        "argsarray": "0.0.1",
+        "clone-buffer": "1.0.0",
+        "immediate": "3.3.0",
+        "inherits": "2.0.4",
+        "pouchdb-collections": "7.3.0",
+        "pouchdb-errors": "7.3.0",
+        "pouchdb-md5": "7.3.0",
+        "uuid": "8.3.2"
+      }
+    },
     "pouchdb-wrappers": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/pouchdb-wrappers/-/pouchdb-wrappers-5.0.0.tgz",
@@ -14253,8 +14544,7 @@
     "spark-md5": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.2.tgz",
-      "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==",
-      "dev": true
+      "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw=="
     },
     "spawn-wrap": {
       "version": "2.0.0",
@@ -14601,6 +14891,18 @@
       "dev": true,
       "requires": {
         "minimist": "^1.1.0"
+      }
+    },
+    "sublevel-pouchdb": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/sublevel-pouchdb/-/sublevel-pouchdb-7.3.0.tgz",
+      "integrity": "sha512-zp7u4jmv2N/s+dXZkWTtL4BjREs3SZ1nGBNNJ8RWX4yqN59oHgKmti4CfVOqfsAW9RMasmTqQAEPxL9hX8+CIA==",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.4",
+        "level-codec": "9.0.2",
+        "ltgt": "2.2.1",
+        "readable-stream": "1.1.14"
       }
     },
     "supports-color": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "homepage": "https://github.com/garbados/comdb#readme",
   "dependencies": {
     "garbados-crypt": "^3.0.0-alpha",
+    "pouchdb-md5": "^7.3.0",
     "transform-pouch": "^2.0.0",
     "tweetnacl": "^1.0.3",
     "tweetnacl-util": "^0.15.1",
@@ -51,6 +52,7 @@
     "mochify": "^9.2.0",
     "nyc": "^15.1.0",
     "pouchdb": "^7.3.0",
+    "pouchdb-adapter-memory": "^7.3.0",
     "standard": "^17.0.0",
     "uglify-js": "^3.15.4"
   }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "cov:node": "nyc -s npm run test:node",
     "cov:browser": "nyc -s --no-clean --instrument false mochify --transform [ babelify --ignore [ test ] --plugins [ babel-plugin-istanbul ] ] test.js",
     "coveralls": "npm run cov && nyc report --reporter=text-lcov > lcov.info",
-    "example": "./examples/couchdb.js"
+    "example": "npm run example:couchdb && npm run example:e2e",
+    "example:couchdb": "./examples/couchdb.js",
+    "example:e2e": "./examples/e2e.js"
   },
   "repository": {
     "type": "git",

--- a/test.js
+++ b/test.js
@@ -205,8 +205,7 @@ describe('ComDB', function () {
 
   describe('replication', function () {
     beforeEach(async function () {
-      this.name2 = [this.name, 'replication', '2'].join('-')
-      this.db2 = new PouchDB(this.name2)
+      this.db2 = new PouchDB(`${this.name}-replication`)
       const exportString = await this.db.exportComDB()
       await this.db2.importComDB(this.password, exportString)
       await this.db.post({ hello: 'sol' })


### PR DESCRIPTION
This PR does a lot because I'm a messy bitch, OK?

- Adds new methods like `db.importComDB()` to make your data more transportable, updates the README accordingly.
- Add `examples/e2e.js` with a demonstration of doing E2E encryption with `pouchdb-adapter-memory`.
- Fixed a weird bug about replicating documents created with `db.post()`.
- **The encrypted database now stores your encryption key, rather than the decrypted database.** *No one stores your password!*

This is a breaking change.

Closes https://github.com/garbados/comdb/issues/23