### PR TITLE
add in-place encryption example

### DIFF
--- a/examples/inplace.js
+++ b/examples/inplace.js
@@ -3,6 +3,7 @@
 
 console.log('# Encrypting an existing decrypted database')
 
+const assert = require('assert').strict
 const PouchDB = require('pouchdb')
 PouchDB.plugin(require('..'))
 
@@ -16,40 +17,70 @@ const NUM_DOCS = 1e3
 const db = new PouchDB(ORIGINAL_DB)
 const db2 = new PouchDB(DECRYPTED_DB)
 
+console.log('')
+console.log(`
+You can encrypt a database "in-place" by copying its contents
+over to a transient replica, encrypting documents as you go.
+Once the replica is finished, empty the original and replicate
+the replica onto it. After that, the original will be encrypted.
+`.trim())
+
 Promise.resolve().then(async () => {
   const startTime = Date.now()
   // add some decrypted data
-  console.log(`Writing ${NUM_DOCS} docs...`)
+  console.log('')
+  console.log(`
+First, we'll load some docs into our unencrypted original,
+to mimic the documents you already have in yours.
+
+Writing ${NUM_DOCS} docs...
+  `.trim())
   const docs = []
   for (let i = 0; i < NUM_DOCS; i++) {
     docs.push({ hello: 'world', i })
   }
   await db.bulkDocs({ docs })
   // set up the encrypted copy
-  console.log('Setting up the encrypted copy...')
+  console.log('')
+  console.log('Setting up the transient encrypted copy...')
   await db.setPassword(PASSWORD, { name: TRANSIENT_DB })
-  console.log('Loading docs into encrypted copy...')
+  console.log('')
+  console.log('Encrypting docs and load them into the transient copy...')
   await db.loadDecrypted()
   // get the export string, because it won't replicate
-  console.log('Preparing to export to new database...')
+  console.log('')
+  console.log('Saving the export string needed for decryption...')
   const exportString = await db.exportComDB()
   // now delete the decrypted copy
-  console.log('>> DESTROYING ORIGINAL <<')
+  console.log('')
+  console.log('>> EMPTYING ORIGINAL <<')
   await db.destroy({ unencrypted_only: true })
   // copy the encrypted copy over the original
-  console.log('Replicating encrypted copy over original...')
-  await PouchDB.replicate(TRANSIENT_DB, ORIGINAL_DB)
+  console.log('')
+  console.log('Replicating encrypted transient copy to populate emptied original...')
+  await PouchDB.replicate(db._encrypted, ORIGINAL_DB)
   await db._encrypted.destroy()
   // now you can use the original DB as an encrypted copy
-  console.log('Setting up new database to use original as encrypted copy...')
+  console.log('')
+  console.log(`
+In order to decrypt documents, both a password and an export string are required.
+So, we set up the now-encrypted original with the export string from the
+transient copy. Then you will be able to decrypt documents.
+
+Using the saved export string to set up decryption with new original...
+  `.trim())
   await db2.importComDB(PASSWORD, exportString, { name: ORIGINAL_DB })
-  console.log('Loading docs from encrypted copy...')
+  console.log('')
+  console.log('Loading docs from original into the new decrypted database...')
   await db2.loadEncrypted()
+  console.log('')
   console.log('Verifying that all expected contents have been copied over...')
   const result = await db2.allDocs()
-  console.log(`Final DB has ${result.total_rows} decrypted documents in it.`)
-  console.log(NUM_DOCS === result.total_rows ? 'OK!' : 'ERROR')
+  console.log('')
+  console.log(`New decrypted database has ${result.total_rows} documents in it.`)
+  assert.equal(NUM_DOCS, result.total_rows)
   const endTime = Date.now()
+  console.log('')
   console.log(`Encrypting ${NUM_DOCS} in place took ${endTime - startTime}ms.`)
 }).catch(console.error).then(async () => {
   await Promise.allSettled([db.destroy(), db2.destroy()])

--- a/examples/inplace.js
+++ b/examples/inplace.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+'use strict'
+
+console.log('# Encrypting an existing decrypted database')
+
+const PouchDB = require('pouchdb')
+PouchDB.plugin(require('..'))
+
+const PASSWORD = process.env.COMDB_PASSWORD || 'everything-to-everyone'
+const ORIGINAL_DB = process.env.ORIGINAL_COUCH_URL || '.original'
+const ENCRYPTED_DB = process.env.ENCRYPTED_COUCH_URL || '.encrypted'
+const DECRYPTED_DB = process.env.DECRYPTED_COUCH_URL || '.decrypted'
+
+const NUM_DOCS = 1e2
+
+const db = new PouchDB(ORIGINAL_DB)
+const db2 = new PouchDB(DECRYPTED_DB)
+
+Promise.resolve().then(async () => {
+  // add some decrypted data
+  console.log(`Writing ${NUM_DOCS} docs...`)
+  const docs = []
+  for (let i = 0; i < NUM_DOCS; i++) {
+    docs.push({ hello: 'world', i })
+  }
+  await db.bulkDocs({ docs })
+  // set up the encrypted copy
+  console.log('Setting up the encrypted copy...')
+  await db.setPassword(PASSWORD, { name: ENCRYPTED_DB })
+  await db.loadDecrypted()
+  // get the export string, because it won't replicate
+  console.log('Preparing to export to new database...')
+  const exportString = await db.exportComDB()
+  // now delete the decrypted copy
+  console.log('>> DESTROYING ORIGINAL <<')
+  await db.destroy({ unencrypted_only: true })
+  // copy the encrypted copy over the original
+  console.log('Replicating encrypted copy over original...')
+  await PouchDB.replicate(ENCRYPTED_DB, ORIGINAL_DB)
+  // now you can use the original DB as an encrypted copy
+  console.log('Setting up new database to use original as encrypted copy...')
+  await db2.importComDB(PASSWORD, exportString, { name: ORIGINAL_DB })
+  await db2.loadEncrypted()
+  console.log('Verifying that all expected contents have been copied over...')
+  const result = await db2.allDocs()
+  console.log(`Final DB has ${result.total_rows} decrypted documents in it.`)
+  console.log(NUM_DOCS === result.total_rows ? 'OK!' : 'ERROR')
+}).catch(console.warn).then(async () => {
+  await Promise.allSettled([db.destroy(), db2.destroy()])
+})

--- a/examples/inplace.js
+++ b/examples/inplace.js
@@ -27,6 +27,7 @@ Promise.resolve().then(async () => {
   // set up the encrypted copy
   console.log('Setting up the encrypted copy...')
   await db.setPassword(PASSWORD, { name: ENCRYPTED_DB })
+  console.log('Loading docs into encrypted copy...')
   await db.loadDecrypted()
   // get the export string, because it won't replicate
   console.log('Preparing to export to new database...')
@@ -37,6 +38,7 @@ Promise.resolve().then(async () => {
   // copy the encrypted copy over the original
   console.log('Replicating encrypted copy over original...')
   await PouchDB.replicate(ENCRYPTED_DB, ORIGINAL_DB)
+  await db._encrypted.destroy()
   // now you can use the original DB as an encrypted copy
   console.log('Setting up new database to use original as encrypted copy...')
   await db2.importComDB(PASSWORD, exportString, { name: ORIGINAL_DB })
@@ -45,6 +47,6 @@ Promise.resolve().then(async () => {
   const result = await db2.allDocs()
   console.log(`Final DB has ${result.total_rows} decrypted documents in it.`)
   console.log(NUM_DOCS === result.total_rows ? 'OK!' : 'ERROR')
-}).catch(console.warn).then(async () => {
+}).catch(console.error).then(async () => {
   await Promise.allSettled([db.destroy(), db2.destroy()])
 })

--- a/examples/inplace.js
+++ b/examples/inplace.js
@@ -8,7 +8,7 @@ PouchDB.plugin(require('..'))
 
 const PASSWORD = process.env.COMDB_PASSWORD || 'everything-to-everyone'
 const ORIGINAL_DB = process.env.ORIGINAL_COUCH_URL || '.original'
-const ENCRYPTED_DB = process.env.ENCRYPTED_COUCH_URL || '.encrypted'
+const TRANSIENT_DB = process.env.TRANSIENT_COUCH_URL || '.encrypted'
 const DECRYPTED_DB = process.env.DECRYPTED_COUCH_URL || '.decrypted'
 
 const NUM_DOCS = 1e3
@@ -27,7 +27,7 @@ Promise.resolve().then(async () => {
   await db.bulkDocs({ docs })
   // set up the encrypted copy
   console.log('Setting up the encrypted copy...')
-  await db.setPassword(PASSWORD, { name: ENCRYPTED_DB })
+  await db.setPassword(PASSWORD, { name: TRANSIENT_DB })
   console.log('Loading docs into encrypted copy...')
   await db.loadDecrypted()
   // get the export string, because it won't replicate
@@ -38,7 +38,7 @@ Promise.resolve().then(async () => {
   await db.destroy({ unencrypted_only: true })
   // copy the encrypted copy over the original
   console.log('Replicating encrypted copy over original...')
-  await PouchDB.replicate(ENCRYPTED_DB, ORIGINAL_DB)
+  await PouchDB.replicate(TRANSIENT_DB, ORIGINAL_DB)
   await db._encrypted.destroy()
   // now you can use the original DB as an encrypted copy
   console.log('Setting up new database to use original as encrypted copy...')

--- a/package.json
+++ b/package.json
@@ -16,9 +16,10 @@
     "cov:node": "nyc -s npm run test:node",
     "cov:browser": "nyc -s --no-clean --instrument false mochify --transform [ babelify --ignore [ test ] --plugins [ babel-plugin-istanbul ] ] test.js",
     "coveralls": "npm run cov && nyc report --reporter=text-lcov > lcov.info",
-    "example": "npm run example:couchdb && npm run example:e2e",
+    "example": "npm run example:couchdb && npm run example:e2e && npm run example:inplace",
     "example:couchdb": "./examples/couchdb.js",
-    "example:e2e": "./examples/e2e.js"
+    "example:e2e": "./examples/e2e.js",
+    "example:inplace": "./examples/inplace.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR adds a new example that demonstrates how to encrypt a database "in-place." This process has a few steps:

- Create a transient copy of the original database.
- Fetch the transient copy's export string.
- Delete the original database.
- Replicate the transient copy to the original database.
- Set up a new decrypted copy that uses the now-encrypted original database as its encrypted copy.
- Load the encrypted documents into the decrypted copy.
- Done!

This example closes https://github.com/garbados/comdb/issues/27 by demonstrating a solution to encrypting a database in-place.

**NOTE: THE DATABASE BEING ENCRYPTED WILL BE UNAVAILABLE DURING THIS PROCESS. READS DURING THIS PROCESS MAY RETURN UNEXPECTED DATA, AND WRITES MAY BE LOST. DO NOT USE THE DATABASE DURING THE ENCRYPTION PROCESS.**