### PR TITLE
chore: add queue to loadDecrypted

### DIFF
--- a/index.js
+++ b/index.js
@@ -194,7 +194,7 @@ module.exports = function (PouchDB) {
     let docs = []
     changes.on('change', ({ doc }) => {
       docs.push(doc)
-      if (docs.length >= 1000) {
+      if (docs.length >= 100) {
         promises.push(this._encrypted.bulkDocs({ docs }))
         docs = []
       }
@@ -204,6 +204,7 @@ module.exports = function (PouchDB) {
     } else {
       const closed = new Promise((resolve, reject) => {
         changes.on('complete', () => {
+          // istanbul ignore else
           if (docs.length) {
             promises.push(this._encrypted.bulkDocs({ docs }))
           }

--- a/test.js
+++ b/test.js
@@ -358,4 +358,34 @@ describe('ComDB', function () {
       assert.equal(result.length, k)
     })
   })
+
+  describe('loadDecrypted queue', function () {
+    const NUM_DOCS = 150
+
+    beforeEach(async function () {
+      this.db2 = new PouchDB('.test-load-decrypted')
+      // add docs to DB
+      const docs = []
+      for (let i = 0; i < NUM_DOCS; i++) {
+        docs.push({ hello: 'world', i })
+      }
+      await this.db2.bulkDocs({ docs })
+      await this.db2.setPassword(this.password)
+    })
+
+    afterEach(async function () {
+      await this.db2.destroy()
+    })
+
+    it('should load decrypted docs efficiently', async function () {
+      const bulkDocs = this.db2._encrypted.bulkDocs
+      let callCount = 0
+      this.db2._encrypted.bulkDocs = async function () {
+        callCount++
+        return bulkDocs.apply(this, arguments)
+      }
+      await this.db2.loadDecrypted()
+      assert.equal(callCount, 2)
+    })
+  })
 })


### PR DESCRIPTION
This PR uses a queue to make loading decrypted docs into an encrypted copy faster and more efficient. Previously, each decrypted doc would be loaded into the encrypted copy one-by-one. This is very slow. Instead, we load docs into an in-memory queue from which we load documents into the database in bulk. The queue's harvest limit is 100. That is, whenever the queue exceeds 100 documents, those documents are loaded into the database and the queue is reset. At the end of `loadDecrypted()` any remaining docs are also loaded en masse.